### PR TITLE
fix(server): arbitrary file access during archive extraction archive

### DIFF
--- a/server/channels/utils/archive.go
+++ b/server/channels/utils/archive.go
@@ -12,13 +12,20 @@ import (
 	"strings"
 )
 
-func sanitizePath(p string) string {
-	dir := strings.ReplaceAll(filepath.Dir(filepath.Clean(p)), "..", "")
-	base := filepath.Base(p)
-	if strings.Count(base, ".") == len(base) {
-		return ""
+func sanitizePath(outPath, p string) (string, error) {
+	cleanedPath := filepath.Clean(p)
+	absOutPath, err := filepath.Abs(outPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve absolute output path: %w", err)
 	}
-	return filepath.Join(dir, base)
+	absPath, err := filepath.Abs(filepath.Join(absOutPath, cleanedPath))
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve absolute file path: %w", err)
+	}
+	if !strings.HasPrefix(absPath, absOutPath) {
+		return "", fmt.Errorf("invalid filepath `%s`", p)
+	}
+	return absPath, nil
 }
 
 // UnzipToPath extracts a given zip archive into a given path.
@@ -31,11 +38,11 @@ func UnzipToPath(zipFile io.ReaderAt, size int64, outPath string) ([]string, err
 
 	paths := make([]string, len(rd.File))
 	for i, f := range rd.File {
-		filePath := sanitizePath(f.Name)
-		if filePath == "" {
-			return nil, fmt.Errorf("invalid filepath `%s`", f.Name)
+		filePath, err := sanitizePath(outPath, f.Name)
+		if err != nil {
+			return nil, fmt.Errorf("invalid filepath `%s`: %w", f.Name, err)
 		}
-		path := filepath.Join(outPath, filePath)
+		path := filePath
 		paths[i] = path
 		if f.FileInfo().IsDir() {
 			if err := os.Mkdir(path, 0700); err != nil {


### PR DESCRIPTION
https://github.com/Infomaniak/kchat-webapp/blob/204e5729bbf86d89f4a490a349761fcab06eb7d2/server/channels/utils/archive.go#L15-L21
https://github.com/Infomaniak/kchat-webapp/blob/204e5729bbf86d89f4a490a349761fcab06eb7d2/server/channels/utils/archive.go#L33-L66
fix the issue, we need to ensure that the resolved file paths are strictly confined to the `outPath` directory. This can be achieved by resolving the absolute path of the constructed file path and verifying that it starts with the absolute path of `outPath`. If the resolved path does not start with the `outPath` prefix, it should be rejected as unsafe.

1. Modify the `sanitizePath` function to ensure that the resolved path is within the `outPath` directory.
2. Use `filepath.Abs` to resolve the absolute path of both `outPath` and the constructed file path.
3. Check that the resolved file path starts with the absolute `outPath` prefix.
4. Reject any paths that fail this check.

#### References
[OWASP A3:2021](https://owasp.org/Top10/A03_2021-Injection/)
[CWE-22](https://cwe.mitre.org/data/definitions/22.html)
[e3e63a13413f](https://medium.com/@ibm_ptc_security/zip-slip-attack-e3e63a13413f)